### PR TITLE
Add ability to create/update assembly and platforms in one method

### DIFF
--- a/src/main/java/com/oneops/boo/BooCli.java
+++ b/src/main/java/com/oneops/boo/BooCli.java
@@ -621,6 +621,20 @@ public class BooCli {
   }
 
   /**
+   *  Creates platforms if the assembly does exist. Updates the platform/components if assembly already exists
+   * @throws BooException
+   * @throws OneOpsClientAPIException
+   */
+  public void createOrUpdatePlatforms()
+          throws BooException, OneOpsClientAPIException {
+    if (flow.isAssemblyExist()) {
+      flow.process(Boolean.TRUE, Boolean.FALSE);
+    } else {
+      flow.process(Boolean.FALSE, Boolean.FALSE);
+    }
+  }
+
+  /**
    * Limit to 32 characters long.
    *
    * @param isAutoGen the is auto gen


### PR DESCRIPTION
 If an assembly exists, update the platforms. If it does not, create the whole oneops hierarchy