### PR TITLE
Update platform variable if already existing. Create if not.

### DIFF
--- a/src/main/java/com/oneops/boo/BooCli.java
+++ b/src/main/java/com/oneops/boo/BooCli.java
@@ -621,7 +621,7 @@ public class BooCli {
   }
 
   /**
-   *  Creates platforms if the assembly does exist. Updates the platform/components if assembly already exists
+   *  Creates platforms if the assembly does not exist. Updates the platform/components if assembly already exists
    * @throws BooException
    * @throws OneOpsClientAPIException
    */

--- a/src/main/java/com/oneops/boo/workflow/BuildAllPlatforms.java
+++ b/src/main/java/com/oneops/boo/workflow/BuildAllPlatforms.java
@@ -420,15 +420,7 @@ public class BuildAllPlatforms extends AbstractWorkflow {
    */
   private void updateOrAddPlatformVariablesIntl(String platformName, Map<String, String> variables,
       boolean isSecure, boolean isUpdate) throws OneOpsClientAPIException {
-    if (!isUpdate) {
-      design.addPlatformVariable(platformName, variables, isSecure);
-    } else {
-      try {
-        design.updatePlatformVariable(platformName, variables, isSecure);
-      } catch (OneOpsClientAPIException e) {
-        design.addPlatformVariable(platformName, variables, isSecure);
-      }
-    }
+    design.updateOrAddPlatformVariables(platformName, variables, isSecure);
   }
 
   /**


### PR DESCRIPTION
For a platform that has default variables as part of pack definition, the design commit was failing in case the boo yaml was overriding the variable. 
This changed code would update the variable if it already existed (as part of creating the platform)