### PR TITLE
Return deployment object at the end of boo run

### DIFF
--- a/src/main/java/com/oneops/boo/workflow/AbstractWorkflow.java
+++ b/src/main/java/com/oneops/boo/workflow/AbstractWorkflow.java
@@ -127,7 +127,7 @@ public abstract class AbstractWorkflow {
    * @return true, if successful
    * @throws OneOpsClientAPIException the one ops client API exception
    */
-  public abstract boolean process(boolean isUpdate, boolean isAssemblyOnly)
+  public abstract Deployment process(boolean isUpdate, boolean isAssemblyOnly)
       throws OneOpsClientAPIException;
 
   /**
@@ -921,7 +921,7 @@ public abstract class AbstractWorkflow {
    * @return true, if successful
    * @throws OneOpsClientAPIException the one ops client API exception
    */
-  public boolean deploy(boolean isUpdate) throws OneOpsClientAPIException {
+  public Deployment deploy(boolean isUpdate) throws OneOpsClientAPIException {
     Deployment response;
     if (StringUtils.isBlank(this.comments)) {
       if (isUpdate) {
@@ -932,7 +932,7 @@ public abstract class AbstractWorkflow {
     } else {
       response = transition.deploy(envName, comments);
     }
-    return response == null ? false : true;
+    return response;
   }
 
 

--- a/src/test/java/com/oneops/boo/ITBuildAllPlatforms.java
+++ b/src/test/java/com/oneops/boo/ITBuildAllPlatforms.java
@@ -85,7 +85,7 @@ public class ITBuildAllPlatforms extends BooTest {
     removeAssembly();
 
     System.out.println("Deploy");
-    assertTrue(build.process(false, false));
+    assertNotNull(build.process(false, false));
     while (build.getStatus().equalsIgnoreCase("active")) {
       TimeUnit.SECONDS.sleep(10);
     }


### PR DESCRIPTION
Instead of returning after starting the deployment, wait and query the deployment state periodically until deployment either reaches an "end state" or times out. 
At the end of it, return the deployment object.
