### PR TITLE
Fix NPE on missing boo config file

### DIFF
--- a/src/main/java/com/oneops/boo/BooConfigInterpolator.java
+++ b/src/main/java/com/oneops/boo/BooConfigInterpolator.java
@@ -66,7 +66,7 @@ public class BooConfigInterpolator {
   }
 
   public String interpolate(String booYaml, File booConfigFile, String profile) throws IOException {
-    if (booConfigFile.exists()) {
+    if (booConfigFile != null && booConfigFile.exists()) {
       Map<String, String> config = iniReader.read(booConfigFile, profile);
       return interpolate(booYaml, config);
     } else {


### PR DESCRIPTION
`OneOpsConfigReader` [returns null](https://github.com/oneops/oneops-client-config/blob/master/src/main/java/com/oneops/client/OneOpsConfigReader.java#L39) if the boo config file does not exist, which results in an NPE crash.